### PR TITLE
TooBigMessageError

### DIFF
--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -114,7 +114,21 @@ RSpec.describe FlowmailerRails::Mailer do
       before do
         stub_access_token
         stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
-          .to_return(status: 420, body: "")
+          .to_return(status: 420, body: "hej")
+      end
+
+      it "raises DeliveryError" do
+        mail = Mail.new(to: "john@example.com")
+
+        expect { subject.deliver!(mail) }.to raise_error(FlowmailerRails::Mailer::DeliveryError)
+      end
+    end
+
+    context "with empty body" do
+      before do
+        stub_access_token
+        stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
+          .to_return(status: 420, body: nil)
       end
 
       it "raises DeliveryError" do

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -109,5 +109,36 @@ RSpec.describe FlowmailerRails::Mailer do
         }.to raise_error(FlowmailerRails::Mailer::NoAccessTokenError)
       end
     end
+
+    context 'with unsuccessful response' do
+      before do
+        stub_access_token
+        stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
+          .to_return(status: 420, body: "")
+      end
+
+      it 'raises DeliveryError' do
+        mail = Mail.new(to: 'john@example.com')
+
+        expect { subject.deliver!(mail) }.to raise_error(FlowmailerRails::Mailer::DeliveryError)
+      end
+    end
+
+    context 'with too big message' do
+      let(:mailer) { described_class.new(account_id: 1337, client_id: 'client-123', client_secret: 'secret-123') }
+
+      before do
+        stub_access_token
+        response_body = { allErrors: [{ code: "message.toobig", defaultMessage: "Message too big 10658211 > 10485760" }]}
+        stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
+          .to_return(status: 422, body: response_body.to_json, headers: { "Content-type": "application/json" })
+      end
+
+      it 'raises TooBigMessageError' do
+        mail = Mail.new(to: 'john@example.com')
+
+        expect { mailer.deliver!(mail) }.to raise_error(FlowmailerRails::Mailer::TooBigMessageError)
+      end
+    end
   end
 end

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -110,32 +110,32 @@ RSpec.describe FlowmailerRails::Mailer do
       end
     end
 
-    context 'with unsuccessful response' do
+    context "with unsuccessful response" do
       before do
         stub_access_token
         stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
           .to_return(status: 420, body: "")
       end
 
-      it 'raises DeliveryError' do
-        mail = Mail.new(to: 'john@example.com')
+      it "raises DeliveryError" do
+        mail = Mail.new(to: "john@example.com")
 
         expect { subject.deliver!(mail) }.to raise_error(FlowmailerRails::Mailer::DeliveryError)
       end
     end
 
-    context 'with too big message' do
-      let(:mailer) { described_class.new(account_id: 1337, client_id: 'client-123', client_secret: 'secret-123') }
+    context "with too big message" do
+      let(:mailer) { described_class.new(account_id: 1337, client_id: "client-123", client_secret: "secret-123") }
 
       before do
         stub_access_token
-        response_body = { allErrors: [{ code: "message.toobig", defaultMessage: "Message too big 10658211 > 10485760" }]}
+        response_body = {allErrors: [{code: "message.toobig", defaultMessage: "Message too big 10658211 > 10485760"}]}
         stub_request(:post, "https://api.flowmailer.net/1337/messages/submit")
-          .to_return(status: 422, body: response_body.to_json, headers: { "Content-type": "application/json" })
+          .to_return(status: 422, body: response_body.to_json, headers: {"Content-type": "application/json"})
       end
 
-      it 'raises TooBigMessageError' do
-        mail = Mail.new(to: 'john@example.com')
+      it "raises TooBigMessageError" do
+        mail = Mail.new(to: "john@example.com")
 
         expect { mailer.deliver!(mail) }.to raise_error(FlowmailerRails::Mailer::TooBigMessageError)
       end


### PR DESCRIPTION
Raise a separate error when the response from flowmailer has `message.toobig` as error code.